### PR TITLE
chore: fix readme to scaffold next template

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,7 +131,7 @@ Run the following npx command to bootstrap your Next.js app from the template.
 
 ```bash
 $ npx create-next-app \
-    -e https://github.com/duynguyen/aem-nextjs-template \
+    -e https://github.com/adobe/aem-nextjs-template \
     --use-npm \
     aem-nextjs-app
 ```


### PR DESCRIPTION
Fixed readme to point to adobe repo instead of private one

## Description
Fix template link to scaffold nextjs app

## Types of changes

- [X] Chore (non-breaking change, non-logic altered change)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [X] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.